### PR TITLE
Added option to not pair " in Vim files

### DIFF
--- a/README
+++ b/README
@@ -6,10 +6,8 @@ Using this script, typing ``(`` will result in (|), where | is the cursor positi
 
 The paired characters are: [, (, {, ", '
 
-Note: in Vim files, you often do not want pairing of " because it is the comment character. You can use something like this to turn that pairing off in vim files:
+Note: in Vim files (including .vimrc), you may not want pairing of " because it is the comment character. If you set a value for g:autoclose_vim_commentmode, the " character will not be paired if Vim considers the current buffer to be a Vim file.
 
-  if has("autocmd")
-    autocmd FileType vim let g:autoclose_vimfilemode = 1
-  endif
+    let g:autoclose_vim_commentmode = 1
 
 If you like this script, you should also check out surround.vim

--- a/README
+++ b/README
@@ -6,4 +6,10 @@ Using this script, typing ``(`` will result in (|), where | is the cursor positi
 
 The paired characters are: [, (, {, ", '
 
+Note: in Vim files, you often do not want pairing of " because it is the comment character. You can use something like this to turn that pairing off in vim files:
+
+  if has("autocmd")
+    autocmd FileType vim let g:autoclose_vimfilemode = 1
+  endif
+
 If you like this script, you should also check out surround.vim

--- a/README
+++ b/README
@@ -6,8 +6,4 @@ Using this script, typing ``(`` will result in (|), where | is the cursor positi
 
 The paired characters are: [, (, {, ", '
 
-Note: in Vim files (including .vimrc), you may not want pairing of " because it is the comment character. If you set a value for g:autoclose_vim_commentmode, the " character will not be paired if Vim considers the current buffer to be a Vim file.
-
-    let g:autoclose_vim_commentmode = 1
-
 If you like this script, you should also check out surround.vim

--- a/plugin/autoclose.vim
+++ b/plugin/autoclose.vim
@@ -197,9 +197,6 @@ function <SID>QuoteDelim(char) " ---{{{2
     return '"'
   endif
 
-  if (a:char == '"' && exists('b:current_syntax') && b:current_syntax == 'vim' && match(line, '^\s*$'))
-    return '"'
-  endif
   if line[col - 2] == "\\"
     "Inserting a quoted quotation mark into the string
     return a:char

--- a/plugin/autoclose.vim
+++ b/plugin/autoclose.vim
@@ -187,6 +187,10 @@ function <SID>CloseStackPop(char) " ---{{{2
 endf
 
 function <SID>QuoteDelim(char) " ---{{{2
+  if (exists('g:autoclose_vimfilemode') && a:char == '"')
+    iunmap "
+    return '"'
+  endif
   let line = getline('.')
   let col = col('.')
   if line[col - 2] == "\\"

--- a/plugin/autoclose.vim
+++ b/plugin/autoclose.vim
@@ -188,7 +188,7 @@ endf
 
 function <SID>QuoteDelim(char) " ---{{{2
   " If this is a Vim file, and user has requested it, do not pair double-quote
-  if (a:char == '"' && exists('g:autoclose_vim_commentmode') && exists('b:current_syntax') && b:current_syntax == "vim")
+  if (a:char == '"' && exists("g:autoclose_vim_commentmode") && exists("b:current_syntax") && b:current_syntax == "vim")
     return '"'
   endif
   let line = getline('.')

--- a/plugin/autoclose.vim
+++ b/plugin/autoclose.vim
@@ -187,12 +187,19 @@ function <SID>CloseStackPop(char) " ---{{{2
 endf
 
 function <SID>QuoteDelim(char) " ---{{{2
-  " If this is a Vim file, and user has requested it, do not pair double-quote
-  if (a:char == '"' && exists("g:autoclose_vim_commentmode") && exists("b:current_syntax") && b:current_syntax == "vim")
-    return '"'
-  endif
   let line = getline('.')
   let col = col('.')
+
+  " In Vim syntax, double-quote is paired only if it's not the first thing
+  " on the line. This is for commenting use. It doesn't cover right-hand
+  " comments, but hey, you shouldn't use those anyway...
+  if (a:char == '"' && exists('b:current_syntax') && b:current_syntax ==# 'vim' && line =~ '^\s*$')
+    return '"'
+  endif
+
+  if (a:char == '"' && exists('b:current_syntax') && b:current_syntax == 'vim' && match(line, '^\s*$'))
+    return '"'
+  endif
   if line[col - 2] == "\\"
     "Inserting a quoted quotation mark into the string
     return a:char

--- a/plugin/autoclose.vim
+++ b/plugin/autoclose.vim
@@ -187,8 +187,8 @@ function <SID>CloseStackPop(char) " ---{{{2
 endf
 
 function <SID>QuoteDelim(char) " ---{{{2
-  if (exists('g:autoclose_vimfilemode') && a:char == '"')
-    iunmap "
+  " If this is a Vim file, and user has requested it, do not pair double-quote
+  if (a:char == '"' && exists('g:autoclose_vim_commentmode') && exists('b:current_syntax') && b:current_syntax == "vim")
     return '"'
   endif
   let line = getline('.')


### PR DESCRIPTION
Because " is used as a comment character in Vim files, I added an option to disable pairing " when in a file where b:current_syntax is "vim". See README for the option (default behavior is the same as before).
